### PR TITLE
Add pagination to TEI and migration history tables

### DIFF
--- a/src/components/DataMigration/HistoryTei.js
+++ b/src/components/DataMigration/HistoryTei.js
@@ -16,6 +16,7 @@ import { Modal, ModalTitle, ModalContent, ModalActions, ButtonStrip, Button ,
     Menu,
     MenuItem,
     AlertBar,
+    Pagination,
 } from '@dhis2/ui';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -59,6 +60,8 @@ const HistoryTei = () => {
     const [restoreSuccess, setRestoreSuccess] = useState(false);
     const [restoreError, setRestoreError] = useState(null);
     const [selectedTeiDetails, setSelectedTeiDetails] = useState([]);
+    const [pageSize, setPageSize] = useState(5);
+    const [page, setPage] = useState(1);
     const engine = useDataEngine();
     // Track mount status to avoid state update on unmounted
     const isMountedRef = React.useRef(true);
@@ -105,7 +108,8 @@ const HistoryTei = () => {
     // Handle select all checkbox
     const handleSelectAll = (checked) => {
         if (checked) {
-            const allTeiIds = teis.map(tei => tei.id);
+            // Select only items on current page
+            const allTeiIds = paginatedTeis.map(tei => tei.id);
             dispatch(setHistorySelectedTeis(allTeiIds));
         } else {
             dispatch(setHistorySelectedTeis([]));
@@ -171,6 +175,24 @@ const HistoryTei = () => {
     // Only show up to MAX_DISPLAY_ROWS, and if more than MAX_SAFE_HISTORY_ROWS, show warning and do not render table
     const teis = status === 'deleted' ? deletedTeis.slice(0, MAX_DISPLAY_ROWS) : [];
 
+    // Calculate paginated data
+    const paginatedTeis = React.useMemo(() => {
+        const startIndex = (page - 1) * pageSize;
+        const endIndex = startIndex + pageSize;
+        return teis.slice(startIndex, endIndex);
+    }, [teis, page, pageSize]);
+
+    const pageCount = Math.ceil(teis.length / pageSize);
+
+    const handlePageChange = (newPage) => {
+        setPage(newPage);
+    };
+
+    const handlePageSizeChange = (newPageSize) => {
+        setPageSize(newPageSize);
+        setPage(1);
+    };
+
     // Always fetch TEIs (with includeDeleted) when orgUnit or program changes, even in History tab
     React.useEffect(() => {
         if (orgUnitId && programId) {
@@ -212,6 +234,27 @@ const HistoryTei = () => {
                     {/* Table label at the top */}
                     <div style={{ color: 'grey', display: 'flex', alignItems: 'center', marginBottom: 0 }}>
                         <h4 style={{ marginLeft: '16px', marginBottom: 0 }}>{i18n.t(labelText)}</h4>
+                    </div>
+                    {/* Pagination above table */}
+                    <div style={{ marginBottom: '16px' }}>
+                        <Pagination
+                            page={page}
+                            pageCount={pageCount}
+                            pageSize={pageSize}
+                            total={teis.length}
+                            onPageChange={handlePageChange}
+                            onPageSizeChange={handlePageSizeChange}
+                            className="pagination-white-buttons"
+                        />
+                        <style>{`
+                            .pagination-white-buttons button {
+                                background-color: white !important;
+                                color: #333 !important;
+                            }
+                            .pagination-white-buttons button:hover {
+                                background-color: #f5f5f5 !important;
+                            }
+                        `}</style>
                     </div>
                     {/* Controls below the label */}
                     <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 4, marginBottom: 8 }}>
@@ -257,8 +300,8 @@ const HistoryTei = () => {
                             <TableRowHead>
                                 <TableCellHead className={classes.checkbox}>
                                     <Checkbox
-                                        checked={selectedTeis.length === teis.length && teis.length > 0}
-                                        indeterminate={selectedTeis.length > 0 && selectedTeis.length < teis.length}
+                                        checked={selectedTeis.length === paginatedTeis.length && paginatedTeis.length > 0}
+                                        indeterminate={selectedTeis.length > 0 && selectedTeis.length < paginatedTeis.length}
                                         onChange={({ checked }) => handleSelectAll(checked)}
                                     />
                                 </TableCellHead>
@@ -288,14 +331,14 @@ const HistoryTei = () => {
                             </TableRowHead>
                         </TableHead>
                         <TableBody className={classes.bodyTable}>
-                            {teis.length === 0 ? (
+                            {paginatedTeis.length === 0 ? (
                                 <TableRow>
                                     <TableCell colSpan={`${6 + attributesToDisplay.length}`} style={{ textAlign: 'center', color: '#888' }}>
                                         {i18n.t('No deleted TEIs found for this org unit and program.')}
                                     </TableCell>
                                 </TableRow>
                             ) : (
-                                teis.map((instance) => (
+                                paginatedTeis.map((instance) => (
                                     <TableRow key={instance.id}>
                                         <TableCell className={classes.checkbox}>
                                             <Checkbox

--- a/src/components/DataMigration/TEIs.js
+++ b/src/components/DataMigration/TEIs.js
@@ -11,6 +11,7 @@ import {
     CircularLoader,
     NoticeBox,
     Checkbox,
+    Pagination,
 } from '@dhis2/ui'
 import React, { useEffect, useState, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -40,6 +41,8 @@ const TEIs = () => {
     const filteredTeis = useMemo(() => filterTeis(activeTeis, filters), [activeTeis, filters])
     const [sortKey, setSortKey] = useState('')
     const [sortDirection, setSortDirection] = useState('default')
+    const [pageSize, setPageSize] = useState(5)
+    const [page, setPage] = useState(1)
 
     useEffect(() => {
         dispatch(dataActionCreators.setProgram(uiProgramId))
@@ -64,6 +67,7 @@ const TEIs = () => {
         setDisplayTeis(filteredTeis)
         setSortKey('')
         setSortDirection('default')
+        setPage(1)
         dispatch(dataActionCreators.setSelectedTEIs([]))
     }, [filteredTeis, dispatch])
 
@@ -141,8 +145,9 @@ const TEIs = () => {
 
     const handleSelectAll = (checked) => {
         if (checked) {
-            const selectedIds = displayTeis.map(tei => tei.id)
-            const selectedTeiObjs = displayTeis.map(tei => ({ id: tei.id, ...tei }))
+            // Select only items on current page
+            const selectedIds = paginatedTeis.map(tei => tei.id)
+            const selectedTeiObjs = paginatedTeis.map(tei => ({ id: tei.id, ...tei }))
             console.log('[History][TEIs Selected][All]', selectedTeiObjs)
             dispatch(dataActionCreators.setSelectedTEIs(selectedIds))
         } else {
@@ -153,7 +158,7 @@ const TEIs = () => {
 
     const handleSelectTei = (teiId) => {
         const isSelected = selectedTeis.includes(teiId)
-        const teiObj = displayTeis.find(tei => tei.id === teiId)
+        const teiObj = initialFilteredTeis.find(tei => tei.id === teiId)
         if (isSelected) {
             console.log('[History][TEI Deselected]', teiObj)
             dispatch(dataActionCreators.setSelectedTEIs(selectedTeis.filter(id => id !== teiId)))
@@ -161,6 +166,24 @@ const TEIs = () => {
             console.log('[History][TEI Selected]', teiObj)
             dispatch(dataActionCreators.setSelectedTEIs([...selectedTeis, teiId]))
         }
+    }
+
+    // Calculate paginated data
+    const paginatedTeis = useMemo(() => {
+        const startIndex = (page - 1) * pageSize
+        const endIndex = startIndex + pageSize
+        return displayTeis.slice(startIndex, endIndex)
+    }, [displayTeis, page, pageSize])
+
+    const pageCount = Math.ceil(displayTeis.length / pageSize)
+
+    const handlePageChange = (newPage) => {
+        setPage(newPage)
+    }
+
+    const handlePageSizeChange = (newPageSize) => {
+        setPageSize(newPageSize)
+        setPage(1)
     }
 
     if (loading) {
@@ -187,6 +210,27 @@ const TEIs = () => {
                         </h4>
                     </div>
 
+                    <div style={{ marginBottom: '16px' }}>
+                        <Pagination
+                            page={page}
+                            pageCount={pageCount}
+                            pageSize={pageSize}
+                            total={displayTeis.length}
+                            onPageChange={handlePageChange}
+                            onPageSizeChange={handlePageSizeChange}
+                            className="pagination-white-buttons"
+                        />
+                        <style>{`
+                            .pagination-white-buttons button {
+                                background-color: white !important;
+                                color: #333 !important;
+                            }
+                            .pagination-white-buttons button:hover {
+                                background-color: #f5f5f5 !important;
+                            }
+                        `}</style>
+                    </div>
+
                     <DataTable>
                         <TableHead>
                             <DataTableRow>
@@ -196,8 +240,8 @@ const TEIs = () => {
                                     key="checkbox-header"
                                 >
                                     <Checkbox
-                                        checked={selectedTeis.length === displayTeis.length && displayTeis.length > 0}
-                                        indeterminate={selectedTeis.length > 0 && selectedTeis.length < displayTeis.length}
+                                        checked={selectedTeis.length === paginatedTeis.length && paginatedTeis.length > 0}
+                                        indeterminate={selectedTeis.length > 0 && selectedTeis.length < paginatedTeis.length}
                                         onChange={({ checked }) => handleSelectAll(checked)}
                                     />
                                 </DataTableColumnHeader>
@@ -261,7 +305,7 @@ const TEIs = () => {
                             </DataTableRow>
                         </TableHead>
                         <TableBody>
-                            {displayTeis.map((instance) => (
+                            {paginatedTeis.map((instance) => (
                                 <DataTableRow key={instance.id}>
                                     <DataTableCell className={classes.checkbox}>
                                         <Checkbox

--- a/src/components/MigrationHistory/MigrationHistoryTable.js
+++ b/src/components/MigrationHistory/MigrationHistoryTable.js
@@ -10,7 +10,7 @@
 import React, { useState, useEffect, memo } from 'react'
 import { useSelector } from 'react-redux'
 import { useDeletedTeisHistory } from '../../hooks/useDeletedTeisHistory'
-import { DataTable, DataTableHead, DataTableRow, DataTableCell, DataTableColumnHeader, DataTableBody, Checkbox } from '@dhis2/ui'
+import { DataTable, DataTableHead, DataTableRow, DataTableCell, DataTableColumnHeader, DataTableBody, Checkbox, Pagination } from '@dhis2/ui'
 
 const ALL_COLUMN_DEFS = [
     { key: 'timestamp', label: 'Timestamp', width: '200px' },
@@ -136,6 +136,8 @@ const MigrationHistoryTable = ({ onSelectionChange, histories: historiesProp, cu
         : ALL_COLUMN_DEFS
     const [expandedBatchId, setExpandedBatchId] = useState(null)
     const [selected, setSelected] = useState(selectedBatches)
+    const [pageSize, setPageSize] = useState(5)
+    const [page, setPage] = useState(1)
     // Only update local selected state if prop changes and is different
     useEffect(() => {
         if (selectedBatches.length !== selected.length || !selectedBatches.every((id, i) => id === selected[i])) {
@@ -168,17 +170,6 @@ const MigrationHistoryTable = ({ onSelectionChange, histories: historiesProp, cu
         })
     }
 
-    const handleSelectAll = () => {
-        if (selected.length === histories.length) {
-            setSelected([])
-        } else {
-            setSelected(histories.map(batch => batch.id))
-        }
-    }
-
-    const areAllBatchesSelected = selected.length === histories.length && histories.length > 0
-    const isPartiallySelected = selected.length > 0 && selected.length < histories.length
-
     // Sorting logic
     function getSortValue(batch, col) {
         if (col === 'timestamp') return batch.timestamp
@@ -196,6 +187,33 @@ const MigrationHistoryTable = ({ onSelectionChange, histories: historiesProp, cu
         if (sortDir === 'asc') return aVal > bVal ? 1 : -1
         return aVal < bVal ? 1 : -1
     })
+
+    // Pagination logic - must come after sortedHistories is defined
+    const paginatedHistories = sortedHistories.slice(
+        (page - 1) * pageSize,
+        (page - 1) * pageSize + pageSize
+    )
+    const pageCount = Math.ceil(sortedHistories.length / pageSize)
+
+    const handleSelectAll = () => {
+        if (selected.length === paginatedHistories.length) {
+            setSelected([])
+        } else {
+            setSelected(paginatedHistories.map(batch => batch.id))
+        }
+    }
+
+    const areAllBatchesSelected = selected.length === paginatedHistories.length && paginatedHistories.length > 0
+    const isPartiallySelected = selected.length > 0 && selected.length < paginatedHistories.length
+
+    const handlePageChange = (newPage) => {
+        setPage(newPage)
+    }
+
+    const handlePageSizeChange = (newPageSize) => {
+        setPageSize(newPageSize)
+        setPage(1)
+    }
 
     // Batch selection safety helpers
     function isBatchUndoable(batch) {
@@ -215,7 +233,28 @@ const MigrationHistoryTable = ({ onSelectionChange, histories: historiesProp, cu
             {histories.length === 0 ? (
                 <p>No migration history found.</p>
             ) : (
-                <DataTable>
+                <>
+                    <div style={{ marginBottom: '16px' }}>
+                        <Pagination
+                            page={page}
+                            pageCount={pageCount}
+                            pageSize={pageSize}
+                            total={sortedHistories.length}
+                            onPageChange={handlePageChange}
+                            onPageSizeChange={handlePageSizeChange}
+                            className="pagination-white-buttons"
+                        />
+                        <style>{`
+                            .pagination-white-buttons button {
+                                background-color: white !important;
+                                color: #333 !important;
+                            }
+                            .pagination-white-buttons button:hover {
+                                background-color: #f5f5f5 !important;
+                            }
+                        `}</style>
+                    </div>
+                    <DataTable>
                     <DataTableHead>
                         <DataTableRow>
                             <DataTableColumnHeader width="48px">
@@ -248,7 +287,7 @@ const MigrationHistoryTable = ({ onSelectionChange, histories: historiesProp, cu
                         </DataTableRow>
                     </DataTableHead>
                     <DataTableBody>
-                        {sortedHistories.map((batch, idx) => (
+                        {paginatedHistories.map((batch, idx) => (
                             <MemoRow
                                 batch={batch}
                                 idx={idx}
@@ -263,6 +302,7 @@ const MigrationHistoryTable = ({ onSelectionChange, histories: historiesProp, cu
                         ))}
                     </DataTableBody>
                 </DataTable>
+                </>
             )}
         </div>
     )


### PR DESCRIPTION
Introduces pagination controls to the TEIs, HistoryTei and MigrationHistoryTable components, limiting displayed rows per page and updating selection logic to operate on paginated data. Enhances usability for large datasets and improves performance by rendering fewer rows at a time.